### PR TITLE
Add ignorecase flag to get_primary_doc_and_infotable_urls functions to fix bug

### DIFF
--- a/parser/crawler_current_events.py
+++ b/parser/crawler_current_events.py
@@ -31,7 +31,7 @@ def get_sec_accession_no(text_13f):
 
 def get_primary_doc_and_infotable_urls(text_13f):
     """Returns the primary_doc.xml and infotable.xml base urls"""
-    return re.findall('(?<=<a href=")(.*)(?=">.*.xml)', text_13f)
+    return re.findall('(?<=<a href=")(.*)(?=">.*.xml)', text_13f, flags=re.IGNORECASE)
 
 
 def get_primary_doc_xml_url(suffix_xml_urls):


### PR DESCRIPTION
Function ignored .XML extension and only grabbed .xml extension.